### PR TITLE
Ignore depositReceiptVersion

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -350,7 +350,7 @@ defmodule EthereumJSONRPC.Receipt do
   end
 
   # Optimism specific transaction receipt fields
-  defp entry_to_elixir({key, _}) when key in ~w(depositNonce) do
+  defp entry_to_elixir({key, _}) when key in ~w(depositNonce depositReceiptVersion) do
     :ignore
   end
 


### PR DESCRIPTION
Required for blockscout to work with latest Optimism upgrades.