### PR TITLE
Disable web tests and build Docker images at the end

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -652,6 +652,10 @@ jobs:
           CHAIN_TYPE: ${{ matrix.chain-type != 'default' && matrix.chain-type || '' }}
           WETH_TOKEN_TRANSFERS_FILTERING_ENABLED: "true"
   test_nethermind_mox_block_scout_web:
+    # Disabling this job for now as it is failing due to the lack of a proper
+    # mocks for the Hemi op-node calls.
+    # See https://github.com/hemilabs/blockscout/issues/15
+    if: false
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.matrix-builder.outputs.matrix) }}

--- a/.github/workflows/publish-docker-image-for-hemi.yml
+++ b/.github/workflows/publish-docker-image-for-hemi.yml
@@ -1,7 +1,11 @@
 name: Hemi Publish Docker image
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Blockscout
+    types:
+      - completed
     branches:
       - production-hemi
   workflow_dispatch:

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -69,7 +69,7 @@ You can adjust BlockScout environment variables:
 Descriptions of the ENVs are available
 
 - for [backend](https://docs.blockscout.com/for-developers/information-and-settings/env-variables)
-- for [frontend](https://github.com/hemilabs/frontend/blob/main/docs/ENVS.md).
+- for [frontend](https://github.com/hemilabs/blockscout-frontend/blob/main/docs/ENVS.md).
 
 ## Running Docker containers via Makefile
 


### PR DESCRIPTION
This PR updates the CI pipeline a bit so the Docker image build/push process is only run after all the checks pass.

It also disables a set of tests called `Blockscout Web Tests` that historically failed for Hemi as some mocks are missing. See #15.

Fixes #16.