### PR TITLE
Enable the reorg monitor

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/optimism.ex
+++ b/apps/indexer/lib/indexer/fetcher/optimism.ex
@@ -379,7 +379,7 @@ defmodule Indexer.Fetcher.Optimism do
   """
   @spec requires_l1_reorg_monitor?() :: boolean()
   def requires_l1_reorg_monitor? do
-    # The SystemConfig contract is not used in Hemi
-    false
+    # The SystemConfig contract is not used in Hemi but the reorg monitor is still needed.
+    true
   end
 end


### PR DESCRIPTION
The reorg monitor was incorrectly disabled in #29 while reverting the changes done to use the new Optimism system configuration contract ([11eed9c](https://github.com/hemilabs/blockscout/pull/29/commits/11eed9cb4109956f5cfbe1d30249f97005868502)). This PR re-enables it.

The reorg monitor is required to index the output roots, transaction batches and withdrawal events.