### PR TITLE
Allow up to 50 MB JSON files to verify contracts

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex
+++ b/apps/block_scout_web/lib/block_scout_web/routers/smart_contracts_api_v2_router.ex
@@ -30,7 +30,7 @@ defmodule BlockScoutWeb.Routers.SmartContractsApiV2Router do
     plug(
       Plug.Parsers,
       parsers: [:urlencoded, :multipart, :json],
-      length: 20_000_000,
+      length: 50_000_000,
       query_string_length: 5_000,
       pass: ["*/*"],
       json_decoder: Poison


### PR DESCRIPTION
In addition to https://github.com/hemilabs/blockscout-frontend/pull/24, the backend also has checks to ensure large payloads are rejected. This PR aims to completely uplift the limit for files when verifying contracts.
