### PR TITLE
Get btc_finality when getting blocks by hash

### DIFF
--- a/apps/explorer/lib/explorer/chain.ex
+++ b/apps/explorer/lib/explorer/chain.ex
@@ -1245,7 +1245,10 @@ defmodule Explorer.Chain do
         {:error, :not_found}
 
       block ->
-        {:ok, block}
+        {:ok,
+         block
+         # Get the BTC finality for the block and add it to the block struct
+         |> Map.put(:btc_finality, OpNode.get_block_btc_finality(block.hash))}
     end
   end
 

--- a/apps/indexer/lib/indexer/block/catchup/fetcher.ex
+++ b/apps/indexer/lib/indexer/block/catchup/fetcher.ex
@@ -92,7 +92,7 @@ defmodule Indexer.Block.Catchup.Fetcher do
   The number of concurrent requests of `blocks_batch_size` to allow against the JSONRPC.
   Defaults to 10.  So, up to `blocks_concurrency * block_batch_size` (defaults to
   `10 * 10`) blocks can be requested from the JSONRPC at once over all
-  connections.  Up to `block_concurrency * receipts_batch_size * receipts_concurrency` (defaults to
+  connections.  Up to `blocks_concurrency * receipts_batch_size * receipts_concurrency` (defaults to
   `#{10 * Block.Fetcher.default_receipts_batch_size() * Block.Fetcher.default_receipts_concurrency()}`
   ) receipts can be requested from the JSONRPC at once over all connections.
   """


### PR DESCRIPTION
When the model (Explorer.Chain) was updated in #4 to include the btc_finality of the block by modifying `number_to_block`, the `hash_to_block` function was left unchanged. Therefore, calls to `/api/v2/blocks/:hash` were not including the finality. This PR fixes that so it resolves #10.

It also fixes a typo in another unrelated file.

Note: The data and control flow follows an MVC pattern. The `BlockScoutWeb.API.V2.BlockController` handles the HTTP request and then asks `Explorer.Chain` (the model) for a block by number or by hash so the `BlockScoutWeb.API.V2.BlockView` renders it.
