### PR TITLE
Add "manual" release workflow

### DIFF
--- a/.github/workflows/publish-docker-image-for-hemi.yml
+++ b/.github/workflows/publish-docker-image-for-hemi.yml
@@ -39,7 +39,7 @@ jobs:
             ADMIN_PANEL_ENABLED=false
             API_V1_READ_METHODS_DISABLED=false
             API_V1_WRITE_METHODS_DISABLED=false
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-beta.+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-hemi+commit.${{ env.SHORT_SHA }}
             CHAIN_TYPE=optimism
             DISABLE_WEBAPP=false
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-hemi.yml
+++ b/.github/workflows/release-hemi.yml
@@ -7,6 +7,9 @@ on:
         description: 'Sequence version of this Hemi release'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/release-hemi.yml
+++ b/.github/workflows/release-hemi.yml
@@ -1,0 +1,44 @@
+name: Release for Hemi
+
+on:
+  workflow_dispatch:
+    inputs:
+      HEMI_VERSION:
+        description: 'Sequence version of this Hemi release'
+        required: true
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: 6.9.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup repo
+        uses: ./.github/actions/setup-repo
+        id: setup
+        with:
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-remote-multi-platform: ''
+      - name: Build and push Docker image (indexer + API)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: hemilabs/blockscout:latest, hemilabs/blockscout:${{ env.RELEASE_VERSION }}-hemi.${{ inputs.HEMI_VERSION }}
+          labels: ${{ steps.setup.outputs.docker-labels }}
+          platforms: |
+            linux/amd64
+          build-args: |
+            ADMIN_PANEL_ENABLED=false
+            API_V1_READ_METHODS_DISABLED=false
+            API_V1_WRITE_METHODS_DISABLED=false
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-hemi.${{ inputs.HEMI_VERSION }}
+            CHAIN_TYPE=optimism
+            DISABLE_WEBAPP=false
+            RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+          provenance: true
+          sbom: true


### PR DESCRIPTION
To allow automating the deployment of new versions, a new release workflow was added. That workflow shall be triggered manually with a sequence number "N" and will produce image tags with the following format: `vX.Y.Z-hemi.N`.