### PR TITLE
Improve the Hemi workflows

### DIFF
--- a/.github/workflows/publish-docker-image-for-hemi.yml
+++ b/.github/workflows/publish-docker-image-for-hemi.yml
@@ -31,7 +31,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: hemilabs/blockscout:latest, hemilabs/blockscout:${{ env.RELEASE_VERSION }}-${{ env.SHORT_SHA }}
+          tags: hemilabs/blockscout:${{ env.RELEASE_VERSION }}-postrelease-${{ env.SHORT_SHA }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
             linux/amd64
@@ -39,7 +39,7 @@ jobs:
             ADMIN_PANEL_ENABLED=false
             API_V1_READ_METHODS_DISABLED=false
             API_V1_WRITE_METHODS_DISABLED=false
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-hemi+commit.${{ env.SHORT_SHA }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}.+commit.${{ env.SHORT_SHA }}
             CHAIN_TYPE=optimism
             DISABLE_WEBAPP=false
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release-hemi.yml
+++ b/.github/workflows/release-hemi.yml
@@ -1,17 +1,16 @@
 name: Release for Hemi
 
 on:
-  workflow_dispatch:
-    inputs:
-      HEMI_VERSION:
-        description: 'Sequence version of this Hemi release'
-        required: true
+  push:
+    tags:
+      - '*'
 
 permissions:
   contents: read
 
 jobs:
   push_to_registry:
+    if: startsWith(github.ref, 'refs/tags/')
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     env:
@@ -31,7 +30,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: hemilabs/blockscout:latest, hemilabs/blockscout:${{ env.RELEASE_VERSION }}-hemi.${{ inputs.HEMI_VERSION }}
+          tags: hemilabs/blockscout:latest, hemilabs/blockscout:${{ env.RELEASE_VERSION }}-hemi.${{ github.ref_name }}
           labels: ${{ steps.setup.outputs.docker-labels }}
           platforms: |
             linux/amd64
@@ -39,7 +38,7 @@ jobs:
             ADMIN_PANEL_ENABLED=false
             API_V1_READ_METHODS_DISABLED=false
             API_V1_WRITE_METHODS_DISABLED=false
-            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-hemi.${{ inputs.HEMI_VERSION }}
+            BLOCKSCOUT_VERSION=v${{ env.RELEASE_VERSION }}-hemi.${{ github.ref_name }}
             CHAIN_TYPE=optimism
             DISABLE_WEBAPP=false
             RELEASE_VERSION=${{ env.RELEASE_VERSION }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ f8a2d95be7d8   redis:alpine                                        "docker-entry
 
 3. ~~The explorer does not detect the chain is a rollup and so does not display L1->L2 deposits or L2->L1 withdrawals in their own list. Rollups likely need additional configuration (and possibly a connection to a regular geth node?).~~
 
+## Build and Deployment Process
+
+When commits are pushed to or PRs are merged into `production-hemi`, Docker images are built with tags following this format: `hemilabs/blockscout:[RELEASE_VERSION]-postrelease-[SHORT_SHA]`.
+
+When a tag is pushed, the "Release for Hemi" workflow is triggered and Docker images are build with these tags: `hemilabs/blockscout:latest` and `hemilabs/blockscout:[RELEASE_VERSION]-hemi.[TAG]`. Tags must be a sequence of positive integers to allow the deployment automation to properly detect the change.
+
 <h1 align="center">Blockscout</h1>
 <p align="center">Blockchain Explorer for inspecting and analyzing EVM Chains.</p>
 <div align="center">


### PR DESCRIPTION
Improve on #45 by aligning the Docker image tags with upstream and triggering the version release on tag instead of manually. Docs were also added.

