### PR TITLE
Ignore more Hemi-specific receipt fields

### DIFF
--- a/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
+++ b/apps/ethereum_jsonrpc/lib/ethereum_jsonrpc/receipt.ex
@@ -459,9 +459,9 @@ defmodule EthereumJSONRPC.Receipt do
     :ignore
   end
 
-  # Hemi specific transaction receipt fields shall be ignored to prevent the
-  # indexer to break. These are not used so ignoring seems right.
-  defp entry_to_elixir({key, _}) when key in ~w(popPayoutNonce) do
+  # Hemi-specific transaction receipt fields shall be ignored to prevent the
+  # indexer from crashing. These are not used so ignoring seems right.
+  defp entry_to_elixir({key, _}) when key in ~w(btcAttributesDepositedNonce popPayoutNonce) do
     :ignore
   end
 


### PR DESCRIPTION
Add `btcAttributesDepositedNonce` to the receipt ignore list to prevent the indexer from crashing.