### PR TITLE
Enhance metadata URI validation

### DIFF
--- a/apps/explorer/lib/explorer/metadata_uri_validator.ex
+++ b/apps/explorer/lib/explorer/metadata_uri_validator.ex
@@ -4,6 +4,7 @@ defmodule Explorer.MetadataURIValidator do
   """
 
   require Logger
+  import Bitwise
 
   @reserved_ranges [
     # Current (local, "this") network
@@ -37,7 +38,22 @@ defmodule Explorer.MetadataURIValidator do
     # Reserved for future use (former Class E network)
     "240.0.0.0/4",
     # Reserved for the "limited [broadcast](https://en.wikipedia.org/wiki/Broadcast_address)" destination address
-    "255.255.255.255/32"
+    "255.255.255.255/32",
+    # IPv4-compatible IPv6 addresses (deprecated, RFC 4291); also covers the unspecified address
+    # (::/128) and loopback (::1/128) since both fall within this range
+    "::/96",
+    # IPv6-mapped IPv4 addresses (e.g. ::ffff:127.0.0.1) — blocks the entire mapped space
+    "::ffff:0.0.0.0/96",
+    # IPv4-translated addresses (RFC 6052)
+    "64:ff9b::/96",
+    # Unique local addresses (ULA, RFC 4193) — IPv6 equivalent of RFC 1918
+    "fc00::/7",
+    # Link-local addresses (IPv6)
+    "fe80::/10",
+    # Documentation (RFC 3849)
+    "2001:db8::/32",
+    # Discard prefix (RFC 6666)
+    "100::/64"
   ]
 
   @doc """
@@ -93,11 +109,37 @@ defmodule Explorer.MetadataURIValidator do
 
   @spec allowed_ip?(tuple()) :: boolean()
   defp allowed_ip?(ip) do
-    not Enum.any?(prepare_cidr_blacklist(), fn range ->
-      range
-      |> InetCidr.contains?(ip)
-    end)
+    blacklist = prepare_cidr_blacklist()
+
+    # Defense-in-depth: if the address is an IPv6-mapped IPv4 (::ffff:x.x.x.x)
+    # or an IPv4-compatible IPv6 address (::a.b.c.d), extract the embedded IPv4
+    # and also check it against IPv4 CIDR ranges.
+    blocked =
+      Enum.any?(blacklist, fn range -> InetCidr.contains?(range, ip) end) ||
+        mapped_ipv4_blocked?(ip, blacklist)
+
+    not blocked
   end
+
+  defp mapped_ipv4_blocked?(ip, blacklist) do
+    case extract_ipv4_from_mapped(ip) do
+      nil -> false
+      ipv4 -> Enum.any?(blacklist, fn range -> InetCidr.contains?(range, ipv4) end)
+    end
+  end
+
+  # Extracts the embedded IPv4 address from an IPv6-mapped IPv4 address.
+  # ::ffff:a.b.c.d is represented as {0, 0, 0, 0, 0, 0xFFFF, (a <<< 8) ||| b, (c <<< 8) ||| d}
+  defp extract_ipv4_from_mapped({0, 0, 0, 0, 0, 0xFFFF, ab, cd}) do
+    {ab >>> 8, ab &&& 0xFF, cd >>> 8, cd &&& 0xFF}
+  end
+
+  # IPv4-compatible IPv6 addresses (deprecated): ::a.b.c.d → {0,0,0,0,0,0, ab, cd}
+  defp extract_ipv4_from_mapped({0, 0, 0, 0, 0, 0, ab, cd}) when ab > 0 or cd > 0 do
+    {ab >>> 8, ab &&& 0xFF, cd >>> 8, cd &&& 0xFF}
+  end
+
+  defp extract_ipv4_from_mapped(_), do: nil
 
   defp prepare_cidr_blacklist do
     from_cache = :persistent_term.get(:parsed_cidr_list, nil)

--- a/apps/explorer/test/explorer/metadata_uri_validator_test.exs
+++ b/apps/explorer/test/explorer/metadata_uri_validator_test.exs
@@ -1,0 +1,111 @@
+defmodule Explorer.MetadataURIValidatorTest do
+  use ExUnit.Case, async: false
+
+  alias Explorer.MetadataURIValidator
+
+  setup do
+    :persistent_term.erase(:parsed_cidr_list)
+
+    prev_env = Application.fetch_env(:indexer, Indexer.Fetcher.TokenInstance.Helper)
+
+    Application.put_env(:indexer, Indexer.Fetcher.TokenInstance.Helper,
+      cidr_blacklist: [],
+      allowed_uri_protocols: ["http", "https"]
+    )
+
+    on_exit(fn ->
+      :persistent_term.erase(:parsed_cidr_list)
+
+      case prev_env do
+        {:ok, value} -> Application.put_env(:indexer, Indexer.Fetcher.TokenInstance.Helper, value)
+        :error -> Application.delete_env(:indexer, Indexer.Fetcher.TokenInstance.Helper)
+      end
+    end)
+
+    :ok
+  end
+
+  describe "validate_uri/1 blocks IPv6-mapped IPv4 addresses" do
+    test "blocks ::ffff:127.0.0.1 (IPv6-mapped loopback)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::ffff:127.0.0.1]:4000/api")
+    end
+
+    test "blocks ::ffff:10.0.0.1 (IPv6-mapped private)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::ffff:10.0.0.1]/metadata")
+    end
+
+    test "blocks ::ffff:192.168.1.1 (IPv6-mapped private)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::ffff:192.168.1.1]/token")
+    end
+
+    test "blocks ::ffff:169.254.0.1 (IPv6-mapped link-local)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::ffff:169.254.0.1]/")
+    end
+
+    test "blocks ::ffff:172.16.0.1 (IPv6-mapped private)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::ffff:172.16.0.1]/")
+    end
+  end
+
+  describe "validate_uri/1 blocks native IPv6 reserved addresses" do
+    test "blocks ::1 (IPv6 loopback)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[::1]:4000/api")
+    end
+
+    test "blocks fe80::1 (link-local)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[fe80::1]/")
+    end
+
+    test "blocks fc00::1 (unique local address)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[fc00::1]/")
+    end
+
+    test "blocks fd00::1 (unique local address)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[fd00::1]/")
+    end
+
+    test "blocks 2001:db8::1 (documentation)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://[2001:db8::1]/")
+    end
+  end
+
+  describe "validate_uri/1 blocks IPv4 reserved addresses" do
+    test "blocks 127.0.0.1 (loopback)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://127.0.0.1:4000/api")
+    end
+
+    test "blocks 10.0.0.1 (private)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://10.0.0.1/metadata")
+    end
+
+    test "blocks 192.168.1.1 (private)" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://192.168.1.1/")
+    end
+
+    test "blocks 0.0.0.0" do
+      assert {:error, :blacklist} = MetadataURIValidator.validate_uri("http://0.0.0.0/")
+    end
+  end
+
+  describe "validate_uri/1 allows valid public addresses" do
+    test "allows a public IPv4 address" do
+      # 8.8.8.8 is a public IP literal — resolved via :inet.parse_address/1, no DNS lookup
+      assert :ok = MetadataURIValidator.validate_uri("http://8.8.8.8/metadata.json")
+    end
+
+    test "allows a public IPv6 address" do
+      # 2600:: is in the public range
+      assert :ok = MetadataURIValidator.validate_uri("http://[2600::1]/metadata.json")
+    end
+  end
+
+  describe "validate_uri/1 rejects invalid URIs" do
+    test "rejects empty host" do
+      assert {:error, :empty_host} = MetadataURIValidator.validate_uri("not_a_uri")
+    end
+
+    test "rejects disallowed protocol" do
+      assert {:error, :disallowed_protocol} = MetadataURIValidator.validate_uri("ftp://example.com/file")
+    end
+  end
+end


### PR DESCRIPTION
This pull request strengthens the IP address validation logic in `Explorer.MetadataURIValidator` to provide more robust protection against requests to private, reserved, and special-use IP ranges, especially for IPv6 and IPv6-mapped IPv4 addresses. It also introduces comprehensive tests to ensure the validator correctly blocks or allows various types of addresses.

**Improvements to IP address validation:**

* Expanded the blacklist in `@reserved_ranges` to include several important IPv6 ranges, such as loopback, unique local, link-local, documentation, and discard prefixes, as well as IPv6-mapped IPv4 and translated address spaces.
* Enhanced the `allowed_ip?/1` logic to detect and block IPv6-mapped IPv4 addresses by extracting and checking the embedded IPv4 address against the blacklist, providing defense-in-depth against bypass attempts.
* Added a helper function `extract_ipv4_from_mapped/1` to correctly parse and handle IPv6-mapped IPv4 addresses.
* Imported the `Bitwise` module to support bitwise operations needed for IPv6 address parsing.

**Testing improvements:**

* Added a new test module `metadata_uri_validator_test.exs` with extensive tests covering IPv4, native IPv6, and IPv6-mapped IPv4 addresses, ensuring the validator blocks all reserved and private ranges and allows valid public addresses. Tests also cover invalid URIs and disallowed protocols.

## Checklist for your Pull Request (PR)

- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I checked whether I should update the docs and did so by submitting a PR to [docs repository](https://github.com/blockscout/docs).
- [x] If I added/changed/removed ENV var, I submitted a PR to [docs repository](https://github.com/blockscout/docs) to update the list of [env vars](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md) and I updated the version to `master` in the Version column. If I removed variable, I added it to [Deprecated ENV Variables](https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables/deprecated-env-variables/README.md) page. After merging docs PR, changes will be reflected in these [pages](https://docs.blockscout.com/for-developers/information-and-settings/env-variables).
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.
