### PR TITLE
Remove logs

### DIFF
--- a/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
@@ -21,13 +21,11 @@ defmodule BlockScoutWeb.CaptchaHelper do
   """
   @spec recaptcha_passed?(%{String.t() => String.t()} | nil) :: bool
   def recaptcha_passed?(%{"recaptcha_v3_response" => recaptcha_response}) do
-    Logger.info("reCAPTCHA v3 verification")
     re_captcha_v3_secret_key = Application.get_env(:block_scout_web, :recaptcha)[:v3_secret_key]
     do_recaptcha_passed?(re_captcha_v3_secret_key, recaptcha_response)
   end
 
   def recaptcha_passed?(%{"recaptcha_response" => recaptcha_response}) do
-    Logger.info("reCAPTCHA v2 verification")
     re_captcha_v2_secret_key = Application.get_env(:block_scout_web, :recaptcha)[:v2_secret_key]
     do_recaptcha_passed?(re_captcha_v2_secret_key, recaptcha_response)
   end

--- a/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
+++ b/apps/block_scout_web/lib/block_scout_web/captcha_helper.ex
@@ -48,7 +48,6 @@ defmodule BlockScoutWeb.CaptchaHelper do
         body |> Jason.decode!() |> success?()
 
       false ->
-        Logger.info("reCAPTCHA is disabled")
         true
 
       error ->
@@ -67,12 +66,8 @@ defmodule BlockScoutWeb.CaptchaHelper do
       Logger.warning("reCAPTCHA v3 low score: #{inspect(score)} < #{inspect(score_threshold())}")
     end
 
-    result =
-      (!check_hostname?() || Helper.get_app_host() == hostname) &&
-        check_recaptcha_v3_score(score)
-
-    Logger.info("reCAPTCHA v3 verification result: #{inspect(result)}")
-    result
+    (!check_hostname?() || Helper.get_app_host() == hostname) &&
+      check_recaptcha_v3_score(score)
   end
 
   # v2 case
@@ -81,9 +76,7 @@ defmodule BlockScoutWeb.CaptchaHelper do
       Logger.warning("reCAPTCHA v2 Hostname mismatch: #{inspect(hostname)} != #{inspect(Helper.get_app_host())}")
     end
 
-    result = !check_hostname?() || Helper.get_app_host() == hostname
-    Logger.info("reCAPTCHA v2 verification result: #{inspect(result)}")
-    result
+    !check_hostname?() || Helper.get_app_host() == hostname
   end
 
   defp success?(resp) do
@@ -92,8 +85,6 @@ defmodule BlockScoutWeb.CaptchaHelper do
   end
 
   defp check_recaptcha_v3_score(score) do
-    Logger.info("reCAPTCHA v3 score: #{inspect(score)}")
-
     if score >= score_threshold() do
       true
     else

--- a/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
+++ b/apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex
@@ -3,8 +3,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
     Display all the Transactions that terminate at this Address.
   """
 
-  require Logger
-
   use BlockScoutWeb, :controller
 
   import BlockScoutWeb.Account.AuthController, only: [current_user: 1]
@@ -179,8 +177,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
          csv_export_module
        )
        when is_binary(address_hash_string) do
-    Logger.info("About to check reCAPTCHA for CSV export")
-
     with {:ok, address_hash} <- Chain.string_to_address_hash(address_hash_string),
          {:address_exists, true} <- {:address_exists, Address.address_exists?(address_hash)},
          {:recaptcha, true} <- {:recaptcha, CaptchaHelper.recaptcha_passed?(params)} do
@@ -203,11 +199,9 @@ defmodule BlockScoutWeb.AddressTransactionController do
         unprocessable_entity(conn)
 
       {:address_exists, false} ->
-        Logger.info("reCAPTCHA not checked as address was not found")
         not_found(conn)
 
       {:recaptcha, false} ->
-        Logger.info("reCAPTCHA check did not pass")
         not_found(conn)
     end
   end
@@ -219,7 +213,6 @@ defmodule BlockScoutWeb.AddressTransactionController do
   end
 
   def transactions_csv(conn, params) do
-    Logger.info("Preparing CSV export with reCAPTCHA: #{inspect(params)}")
     items_csv(conn, params, AddressTransactionCsvExporter)
   end
 


### PR DESCRIPTION
## Motivation

Remove debug logs added previously in #41 and #42.

## Changelog

This pull request primarily removes unnecessary `Logger.info` statements from the `CaptchaHelper` and `AddressTransactionController` modules. This cleanup reduces log noise, making logs more focused on warnings and errors, and improves code readability.

**Logging cleanup:**

* [`apps/block_scout_web/lib/block_scout_web/captcha_helper.ex`](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L24-L30): Removed multiple `Logger.info` statements related to reCAPTCHA verification steps, results, and status messages, retaining only important warnings. [[1]](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L24-L30) [[2]](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L53) [[3]](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L72-L77) [[4]](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L86-R79) [[5]](diffhunk://#diff-82e4586f07c92ce598872e203ad7d4d1b6889c10b53324084493a6970f4d5201L97-L98)
* [`apps/block_scout_web/lib/block_scout_web/controllers/address_transaction_controller.ex`](diffhunk://#diff-54264c24cf6c35ae7bdb4a54eaed647c25c39c75ad7e7d41f636762411063a95L6-L7): Removed `Logger.info` statements that logged the start of reCAPTCHA checks, CSV export preparations, and cases where reCAPTCHA or address checks failed. Also removed the unnecessary `require Logger` line. [[1]](diffhunk://#diff-54264c24cf6c35ae7bdb4a54eaed647c25c39c75ad7e7d41f636762411063a95L6-L7) [[2]](diffhunk://#diff-54264c24cf6c35ae7bdb4a54eaed647c25c39c75ad7e7d41f636762411063a95L182-L183) [[3]](diffhunk://#diff-54264c24cf6c35ae7bdb4a54eaed647c25c39c75ad7e7d41f636762411063a95L206-L210) [[4]](diffhunk://#diff-54264c24cf6c35ae7bdb4a54eaed647c25c39c75ad7e7d41f636762411063a95L222)

No functional changes were made; only logging and related code were affected.

## Checklist for your Pull Request (PR)

- [x] I verified this PR does not break any public APIs, contracts, or interfaces that external consumers depend on.
- [x] If I added new functionality, I added tests covering it.
- [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
- [x] I updated documentation if needed:
  - [x] General docs: submitted PR to [docs repository](https://github.com/blockscout/docs).
  - [x] ENV vars: updated [env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables) and set version parameter to `master`.
  - [x] Deprecated vars: added to [deprecated env vars list](https://github.com/blockscout/docs/tree/main/setup/env-variables/deprecated-env-variables).
- [x] If I modified API endpoints, I updated the Swagger/OpenAPI schemas accordingly and checked that schemas are asserted in tests, and highlighted the change in the PR description.
- [x] If I added new DB indices, I checked, that they are not redundant, with PGHero or other tools.
- [x] If I added/removed chain type, I modified the Github CI matrix and PR labels accordingly.